### PR TITLE
Client sync test

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -11,6 +11,7 @@ int shmid = 0; //shared memory id
 int msgid[NODENUM] = {0, };
 const int proj_id = 0x41;//temp id
 int id;//id for node
+int client_pipe[2];
 
 
 void

--- a/src/project.c
+++ b/src/project.c
@@ -51,9 +51,6 @@ client_write_complete(int sig)
 
 		if(cnt == NODENUM)
 		{
-#ifdef DEBUG
-				printf("parent: send SIGCONT to server %d\n", order);
-#endif
 				kill(servers[order], SIGCONT);//resume server process
 				order = (order + 1) % NODENUM;
 				cnt = 0;
@@ -64,15 +61,10 @@ void
 server_read_complete(int sig)
 {
 		//SIGUSR2 Handler
-		int i = 0;
 #ifdef DEBUG
 		puts("parent: server complete reading, wake all clients");
 #endif
-
-		for(i = 0;i < NODENUM;i++)//resume all clients
-		{
-				kill(clients[i], SIGCONT);
-		}
+		kill(-clients[0], SIGCONT);//send signal to client process group, set in gen_node(common.c)
 }
 
 void
@@ -188,6 +180,7 @@ client_oriented_io()
 		}
 
 		return 0;
+
 }
 
 int


### PR DESCRIPTION
# Changes

## Client.c

- `SIGSTOP` & `SIGCONT`에 문제가 많음
- client에서 `pause()`와 `SIGUSR1` 핸들러를 통한 동기화를 사용하도록 변경
- client 0번이 모든 클라이언트들의 동기화를 관리하는 방식
- 1 ~ 3번 클라이언트는 `SIGUSR1`에 의해 데이터를 읽어서 공유 메모리에 저장
    - `client_pipe`에 쓰기 락을 걸고 1바이트를 씀
    - client 0에서는 for-loop 안에서 `client_pipe`에서 데이터를 1바이트 씩 `NODENUM-1` 번 읽어서 다른 client들이 모두 데이터를 쓸 때까지 대기
    - 데이터를 다 쓰면 parent에 `SIGUSR1`을 보내고 pause
    - parent는 알맞는 server를 깨워서 청크에 데이터를 쓰게 만들고 client 0에게만 SIGUSR2를 보내서 깨움
    - 일어난 client 0는 다시 다른 클라이언트를 깨우고 위의 과정을 반복

# To-Do

1. client에서 데이터를 모두 읽으면 (`EOF`) parent가 모든 프로세스를 종료시키도록