### PR TITLE
Pwndorei

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -22,7 +22,6 @@ extern int shmid;
 static int* shm_addr = NULL;
 extern int msgid[4];
 static int msgi = 0;
-msgbuf msg;
 
 /*
  * signal for sync (Client-Oriented)
@@ -90,6 +89,7 @@ do_client_task(int mode)
 		{
 			while (1)  // send data to msg queue #1 ~ #4
 			{
+				msgbuf msg;
 
 				nbyte = read(fd, &data, sizeof(int) * 2);
 				if (nbyte == -1)

--- a/src/project.h
+++ b/src/project.h
@@ -51,10 +51,6 @@ void do_server_task(int);
 //sighandler for parent
 void client_write_complete(int);//SIGUSR1 handler
 void server_read_complete(int);//SIGUSR2 handler
-void shutdown(int);//SIGINT handler
-
-//sighandler for client
-
 
 
 //time measurement function

--- a/src/server.c
+++ b/src/server.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <signal.h>
 #include <sys/shm.h>
+#include <sys/msg.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -18,7 +19,6 @@ static int fd = -1;
 static int* shm_addr = NULL;
 static int ser_buf[8] = {0, };
 extern int msgid[4];
-msgbuf msg;
 
 
 void
@@ -57,6 +57,7 @@ do_server_task(int mode)
 		}
 		else if(mode == MODE_SVOR)
 		{
+		    msgbuf msg;
 			while(1)
 			{
 				raise(SIGSTOP);  // wait until msg queue is full, signal by parent


### PR DESCRIPTION
# Changes

## client sync in Client-Oriented

-  기존 SIGSTOP & SIGCONT에서 SIGUSR1과 `pause`로 변경
    - server도 `pause`와 SIGUSR1을 사용하도록 변경
- 첫 번째 client(leader)가 나머지 client(worker)간 싱크를 맞추는 역할을 함
    - `pipe`로 client_pipe 초기화
    -  leader의 SIGUSR2 핸들러에서 worker에게 SIGUSR1 전송
        - `gen_node`에서 `setgpid`로 첫 번째 client와 server의  pid로 group pid를 설정, `kill(-getpid(), <SIGNAL>)`로 다른 client/server에 시그널 전송, 자신은 해당 시그널을 무시(SIG_IGN)
    -파일에서 데이터를 읽은 worker는 client_pipe의 write end에 write lock을 걸고 1바이트를 씀(sync를 위함)
        - leader는 `NODENUM-1`번 client_pipe의 read end에 read를 수행 -> 모든  worker가 데이터를 쓰는 것을 기다림, 데이터를 다 쓴 worker는 `pause()`로 대기
        - leader는 parent에 SIGUSR1을 보내고 `pause()`
        - server가 공유메모리에서 데이터를 읽은 다음 parent가 leader에게 SIGUSR2를 보내면 위의 과정이 반복