### PR TITLE
Server-oriented IO

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -53,7 +53,7 @@ shutdown(int sig)
 		}
 		else if(mode == MODE_SVOR)
 		{
-
+				// defined at SVOR EOF
 		}
 		exit(0);
 }
@@ -200,6 +200,7 @@ do_client_task(int mode)
 		{
 			while (1)  // send data to msg queue #1 ~ #4
 			{
+				struct msqid_ds buf;
 				msgbuf msg;
 
 				nbyte = read(fd, &data, sizeof(int) * 2);
@@ -223,7 +224,9 @@ do_client_task(int mode)
 				msgsnd(msgid[msgi++], &msg, sizeof(int), 0);
 				msgi %= NODENUM;
 
-				kill(parent, SIGUSR1);//send SIGUSR1 to parent, notify "data is written!"
+				msgctl(msgid[msgi], IPC_STAT, &buf);
+				if(buf.msg_qnum == 8)//Check if, Is the message queue full?
+					kill(parent, SIGUSR1);//send SIGUSR1 to parent, notify "All datas are written!"
 				raise(SIGSTOP);//stop until parent's SIGCONT
 	
 			}

--- a/src/common.c
+++ b/src/common.c
@@ -58,7 +58,7 @@ create_shm()
 }
 
 void
-create_msgq()
+create_msg_queue()
 {		
 		int i;
 		gen_key();

--- a/src/project.c
+++ b/src/project.c
@@ -170,7 +170,7 @@ server_oriented_io()
 		act.sa_handler = server_read_complete;
 		sigaction(SIGUSR2, &act, NULL);
 
-		create_msgq();
+		create_msg_queue();
 		gen_node(servers, NODENUM, do_server_task, MODE_SVOR);
 		gen_node(clients, NODENUM, do_client_task, MODE_SVOR);
   

--- a/src/server.c
+++ b/src/server.c
@@ -49,7 +49,7 @@ shutdown(int sig)
 		else if(mode == MODE_SVOR)
 		{
 				close(fd);
-				if (msgctl(msg_queue_id, IPC_RMID, NULL) == -1)
+				if (msgctl(msgid[id], IPC_RMID, NULL) == -1)
 				{
        					perror("msgctl");
         				exit(-1);
@@ -95,10 +95,13 @@ do_server_task(int mode)
 		}
 		else if(mode == MODE_SVOR)
 		{
-		    msgbuf msg;
+		    static msgbuf msg;
+			static sigset_t mask;
+			sigemptyset(&mask);
+			sigaddset(&mask, SIGUSR1);
 			while(1)
 			{
-				raise(SIGSTOP);  // wait until msg queue is full, signal by parent
+				sigsuspend(&mask);  // wait until msg queue is full, signal by parent
 				for (int i = 0; i < 8; i++)
 				{	
 					nbyte = msgrcv(msgid[id], &msg, sizeof(int), -7, 0);


### PR DESCRIPTION
Client: msg queue에 2개 입력, 입력 후 queue에 데이터가 8개라면 parent에 kill(SIGUSR1), 작업이 끝나면 raise(SIGSTOP)
Server: Parent에게서 SIGUSR1을 기다리며, message queue에서 데이터를 꺼낸 뒤 own file에 입력 후 parent에 SIGUSR2
Parent: SIGUSR1 - 2개 이상 중복 수신될 수 있으므로 핸들러를 do_nothing으로 바꿈. 서버에 SIGUSR1 -> 서버 일 시작
SIGUSR2 - 서버에게서 받으면 SIGUSR1 핸들러 복구 후 Client들에게 SIGCONT -> 클라이언트 일 시작

그 외 헤더파일 함수명(create_msg_queue) 통일, 안 쓰이는 변수(cnt) 삭제, 오타(msgid[id]) 수정